### PR TITLE
Oppgraderer Distroless til java17-debian11@sha256:bc99bb6d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian11@sha256:b50c5d2f702a755dfaa18463edfd76c6cd0d8cb9a0e3073d99b8392b189aab24
+FROM gcr.io/distroless/java17-debian11@sha256:bc99bb6dfb842c0d07410cb341e1a993b4b75198f6e883315d8dc42588844a16
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli