### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:b7c03dfc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:fe0560fbf87031402f6c725917eabbf9217b5e9fc95fdff9a004dba3587a0513
+FROM gcr.io/distroless/java21-debian12@sha256:b7c03dfcbaf93a7408c8b9fa817d2c973287cfdd1807f6c1724302763887b647
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli