### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:245a5c2b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:b7c03dfcbaf93a7408c8b9fa817d2c973287cfdd1807f6c1724302763887b647
+FROM gcr.io/distroless/java21-debian12@sha256:245a5c2bbdbd5c9f859079f885cd03054340f554c6fcf67f14fef894a926979b
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli