### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:3b8f431c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:245a5c2bbdbd5c9f859079f885cd03054340f554c6fcf67f14fef894a926979b
+FROM gcr.io/distroless/java21-debian12@sha256:3b8f431c1192a24465b0efaa04155d4be2a808279a19aae2a57b5a355f3192df
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli