### PR TITLE
Bump io.confluent:kafka-avro-serializer from 7.6.0 to 7.6.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ val tokenSupportVersion = "4.1.4"
 val logstashLogbackEncoderVersion = "7.4"
 val kluentVersion = "1.73"
 val sykepengesoknadKafkaVersion = "2024.03.21-14.13-5011349f"
-val confluentVersion = "7.6.0"
+val confluentVersion = "7.6.1"
 val doknotifikasjonAvroVersion = "08c0b2d2"
 
 dependencies {
@@ -65,6 +65,7 @@ dependencies {
     testImplementation("org.awaitility:awaitility")
     testImplementation("no.nav.security:token-validation-spring-test:$tokenSupportVersion")
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
+    testImplementation("commons-codec:commons-codec")
 }
 
 kotlin {

--- a/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
@@ -68,7 +68,7 @@ abstract class FellesTestOppsett {
                 System.setProperty("spring.datasource.password", it.password)
             }
 
-            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3")).also {
+            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).also {
                 it.start()
                 System.setProperty("KAFKA_BROKERS", it.bootstrapServers)
             }


### PR DESCRIPTION
La til commons-codec som testImplementation på grunn av at confluent har den som (midlertidig) transitiv avhengighet.
