### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:cf7fce95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:e4cb46a49683df2fd5a93bc669f0c56942d75ea6d08b08f506cc70ca686c5e57
+FROM gcr.io/distroless/java21-debian12@sha256:cf7fce959603124dcc412bc2d245d84a4e0d86c4c02c6eae2cf13e973c246f24
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli