### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:903d5ad2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:4ef80b38c61881bdd4d682df9989a9816f4926f8fb41eaaf55d54a6affe6a6c2
+FROM gcr.io/distroless/java21-debian12@sha256:903d5ad227a4afff8a207cd25c580ed059cc4006bb390eae65fb0361fc9724c3
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Fra flex-cli