### PR TITLE
Migrer dinesykmeldte-hendelser fra tsm til team-esyfo namespace

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/KafkaConfig.kt
@@ -103,4 +103,4 @@ class KafkaConfig(
 }
 
 const val DOKNOTIFIKASJON_TOPIC = "teamdokumenthandtering.privat-dok-notifikasjon-med-kontakt-info"
-const val DINE_SYKMELDTE_HENDELSER_TOPIC = "teamsykmelding.dinesykmeldte-hendelser-v2"
+const val DINE_SYKMELDTE_HENDELSER_TOPIC = "team-esyfo.dinesykmeldte-hendelser-v2"


### PR DESCRIPTION
Vi har tatt over dinesykmeldte og også tatt over noen topics, [dinesykmeldte-hendelser-v2](https://github.com/navikt/dinesykmeldte-backend/blob/main/nais/topics/dinesykmeldte-hendelser-v2.yaml) er en av dem.